### PR TITLE
Fix element actionability for legacy installer controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ tier and verb names. Pin to v0.2.0-rc.5 for the Protocol 2.0 surface.
   `request_update_access`, `request_delete_access`,
   `request_extra_risky_access`. Holding a higher rung subsumes everything
   below per the ladder.
+- **Element actionability.** Element responses now expose tri-state
+  `enabled` and boolean `clickable` fields so legacy installer controls that
+  cannot provide reliable UIA enabled metadata are not silently skipped.
 
 Migration:
 - Clients raising to `drive` should now raise to `update`.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -360,7 +360,7 @@ UI Automation. Element identifiers use the prefix `elt:` followed by a connectio
 | Verb | Tier | Args | Response | Notes |
 |---|---|---|---|---|
 | `element.list` | R | `[--region <x>,<y>,<w>,<h>]` | `OK <len>\n<json>` | Filtered enumeration of interactable / named elements |
-| `element.tree` | R | `<elt-id>` | `OK <len>\n<json>` | TreeWalker recursive descent. JSON: `{"elements":[{"depth":N,"id":"elt:N","role":"...","name":"...","bounds":[x,y,w,h],"flags":[...]}]}` |
+| `element.tree` | R | `<elt-id>` | `OK <len>\n<json>` | TreeWalker recursive descent. JSON: `{"elements":[{"depth":N,"id":"elt:N","role":"...","name":"...","bounds":[x,y,w,h],"flags":[...],"enabled":true/false/null,"clickable":true/false}]}` |
 | `element.at` | R | `<x> <y>` | `OK <len>\n<json>` or `ERR not_found` | Hit test |
 | `element.find` | R | `<role> <name-pattern>` | `OK <len>\n<json>` or `ERR not_found` or `ERR uia_blind` | `not_found` = nothing matched. `uia_blind` = UIA cannot see across the integrity barrier (caller may need to elevate). |
 | `element.wait` | R | `<role> <name-pattern> <timeout-ms>` | `OK <len>\n<json>` or `ERR timeout` | Polling form of `element.find` (re-walks the visible-element subtree every 250 ms until match or deadline). Returned id is valid for `element.invoke` on the same connection. Capability-gated. |
@@ -375,6 +375,8 @@ UI Automation. Element identifiers use the prefix `elt:` followed by a connectio
 | `element.set_text` | U | `<elt-id> <length>` | `OK 0` or `ERR readonly` or `ERR not_supported_by_target` | UTF-8 text payload follows |
 
 Element IDs are allocated by the agent on calls that produce element references (`element.list`, `element.tree`, `element.at`, `element.find`, `element.wait`). IDs remain valid for the connection's lifetime unless the underlying element is invalidated, in which case subsequent verbs return `ERR target_gone`.
+
+Element objects include both the legacy `flags` array and explicit actionability fields. `enabled` is tri-state: `true` means UIA or Win32 confirms the element is enabled, `false` means a disabled state was confirmed, and `null` means the agent could not prove either state. `clickable` is a cheap "worth trying to click" signal for visible, non-zero-sized interactive controls whose enabled state is not confirmed disabled. Installer frameworks and other legacy/custom controls may expose incomplete UIA metadata; callers SHOULD avoid filtering out controls solely because `enabled` is `null`.
 
 ### 4.6 `file.*`
 

--- a/VERBS.md
+++ b/VERBS.md
@@ -80,6 +80,8 @@ UI Automation introspection and control.
 - `element.text` (R): Reads text from the given element via TextPattern (preferred) or ValuePattern (fallback).
 - `element.set_text` (U): Writes text to the given element from a length-prefixed payload; surfaces `readonly` / `not_supported_by_target` distinctly.
 
+Element responses include `enabled` (`true`, `false`, or `null`) and `clickable` in addition to the legacy `flags` array. `null` means UIA/Win32 could not prove the enabled state; callers should not treat it as disabled, especially for legacy installer wizard controls.
+
 ## `file.*`
 
 File operations. UTF-8 paths. For directory-only verbs see `directory.*`.

--- a/agents/windows-modern/src/verbs/element.cpp
+++ b/agents/windows-modern/src/verbs/element.cpp
@@ -145,12 +145,96 @@ std::string bstr_to_utf8(BSTR b) {
     return text::wide_to_utf8(b, len);
 }
 
+enum class EnabledState {
+    Unknown,
+    Disabled,
+    Enabled,
+};
+
+EnabledState native_window_enabled_state(IUIAutomationElement* elem) {
+    UIA_HWND native = 0;
+    if (FAILED(elem->get_CurrentNativeWindowHandle(&native)) || native == 0) {
+        return EnabledState::Unknown;
+    }
+
+    HWND hwnd = reinterpret_cast<HWND>(static_cast<INT_PTR>(native));
+    if (!IsWindow(hwnd)) return EnabledState::Unknown;
+
+    HWND parent = GetAncestor(hwnd, GA_PARENT);
+    if (parent && IsWindow(parent) && !IsWindowEnabled(parent)) {
+        return EnabledState::Disabled;
+    }
+
+    SetLastError(ERROR_SUCCESS);
+    const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+    if (style == 0 && GetLastError() != ERROR_SUCCESS) {
+        return IsWindowEnabled(hwnd) ? EnabledState::Enabled
+                                    : EnabledState::Unknown;
+    }
+
+    if ((style & WS_DISABLED) != 0 || !IsWindowEnabled(hwnd)) {
+        return EnabledState::Disabled;
+    }
+    return EnabledState::Enabled;
+}
+
+EnabledState element_enabled_state(IUIAutomationElement* elem) {
+    BOOL uia_enabled = FALSE;
+    const HRESULT hr = elem->get_CurrentIsEnabled(&uia_enabled);
+
+    // UIA can report legacy/custom installer controls as disabled/unknown even
+    // when their HWND is live. Trust a concrete Win32 disabled style, and let a
+    // live enabled HWND override a false UIA value for those controls.
+    const EnabledState native = native_window_enabled_state(elem);
+    if (native != EnabledState::Unknown) return native;
+
+    if (SUCCEEDED(hr)) {
+        return uia_enabled ? EnabledState::Enabled : EnabledState::Disabled;
+    }
+    return EnabledState::Unknown;
+}
+
+bool element_is_interactive_role(CONTROLTYPEID control_type) {
+    switch (control_type) {
+        case UIA_ButtonControlTypeId:
+        case UIA_CheckBoxControlTypeId:
+        case UIA_ComboBoxControlTypeId:
+        case UIA_HyperlinkControlTypeId:
+        case UIA_ListItemControlTypeId:
+        case UIA_MenuItemControlTypeId:
+        case UIA_RadioButtonControlTypeId:
+        case UIA_SliderControlTypeId:
+        case UIA_SpinnerControlTypeId:
+        case UIA_TabItemControlTypeId:
+        case UIA_TreeItemControlTypeId:
+        case UIA_SplitButtonControlTypeId:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool element_clickable(IUIAutomationElement* elem,
+                       CONTROLTYPEID control_type,
+                       const RECT& rc,
+                       EnabledState enabled) {
+    if (enabled == EnabledState::Disabled) return false;
+    if (rc.right <= rc.left || rc.bottom <= rc.top) return false;
+
+    BOOL offscreen = FALSE;
+    if (SUCCEEDED(elem->get_CurrentIsOffscreen(&offscreen)) && offscreen) {
+        return false;
+    }
+    return element_is_interactive_role(control_type);
+}
+
 // Reads the element's flag bits using cheap-ish properties.
-std::vector<std::string> element_flags(IUIAutomationElement* elem) {
+std::vector<std::string> element_flags(IUIAutomationElement* elem,
+                                       EnabledState enabled) {
     std::vector<std::string> out;
 
     BOOL b = FALSE;
-    if (SUCCEEDED(elem->get_CurrentIsEnabled(&b))         && b) out.emplace_back("enabled");
+    if (enabled == EnabledState::Enabled) out.emplace_back("enabled");
     if (SUCCEEDED(elem->get_CurrentHasKeyboardFocus(&b))  && b) out.emplace_back("focused");
     if (SUCCEEDED(elem->get_CurrentIsOffscreen(&b))       && b) out.emplace_back("offscreen");
     if (SUCCEEDED(elem->get_CurrentIsPassword(&b))        && b) out.emplace_back("password");
@@ -205,7 +289,8 @@ std::string value_pattern_value(IUIAutomationElement* elem) {
 }
 
 // Appends `{"id":"elt:N","role":"...","name":"...","value":"...",
-//          "bounds":[x,y,w,h],"flags":[...]}` to `out`.
+//          "bounds":[x,y,w,h],"flags":[...],"enabled":true|false|null,
+//          "clickable":true|false}` to `out`.
 void append_element_object(std::string& out,
                            const std::string& id,
                            IUIAutomationElement* elem) {
@@ -222,6 +307,9 @@ void append_element_object(std::string& out,
     RECT rc{};
     elem->get_CurrentBoundingRectangle(&rc);
 
+    const EnabledState enabled = element_enabled_state(elem);
+    const bool clickable = element_clickable(elem, ctype, rc, enabled);
+
     out += '{';
     json::append_kv_string(out, "id", id);                       out += ',';
     json::append_kv_string(out, "role", role_token(ctype));      out += ',';
@@ -232,7 +320,21 @@ void append_element_object(std::string& out,
     std::snprintf(bbuf, sizeof(bbuf), ":[%ld,%ld,%ld,%ld],",
                   rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top);
     out += bbuf;
-    json::append_string_array(out, "flags", element_flags(elem));
+    json::append_string_array(out, "flags", element_flags(elem, enabled));
+    out += ',';
+    switch (enabled) {
+        case EnabledState::Enabled:
+            json::append_kv_bool(out, "enabled", true);
+            break;
+        case EnabledState::Disabled:
+            json::append_kv_bool(out, "enabled", false);
+            break;
+        case EnabledState::Unknown:
+            json::append_kv_null(out, "enabled");
+            break;
+    }
+    out += ',';
+    json::append_kv_bool(out, "clickable", clickable);
     out += '}';
 }
 


### PR DESCRIPTION
Fixes #93.

## Summary
- Adds a Win32 HWND fallback for `element.list` / `element.tree` enabled-state detection so legacy installer controls are not collapsed into an empty/false actionability state when UIA metadata is incomplete.
- Adds explicit `enabled: true | false | null` and `clickable: boolean` fields to element objects while preserving the existing `flags` array.
- Documents the tri-state contract and the legacy-installer caller guidance.

## Validation
- `git diff --check`
- `python3 -m py_compile mcp-server/tools.py mcp-server/spec_loader.py`

Blocked locally: the Windows agent target cannot be built on this macOS runner (`agents/windows-modern/CMakeLists.txt` requires `WIN32`), and the active Python environment does not have `pytest` installed for `mcp-server/tests/test_spec_loader.py`.
